### PR TITLE
Add build status badge to repository README (fixes #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
+
+[![Build Status](https://travis-ci.org/xiaodaigh/FstFileFormat.jl.svg?branch=master)](https://travis-ci.org/xiaodaigh/FstFileFormat.jl)
+
 # About
+
 This is the Julia bindings for the fst format (http://www.fstpackage.org) although the format was originally designed to work with R it is language independent.
 
 # How to use


### PR DESCRIPTION
Hi @xiaodaigh, this is just a small update to the README to show the Travis build status as requested in issue #6